### PR TITLE
Fix case-sensitive test path matching in patch splitting

### DIFF
--- a/curation/swe_task_crawling/utils.py
+++ b/curation/swe_task_crawling/utils.py
@@ -404,7 +404,7 @@ def extract_patches(pull: dict, repo: Repo) -> tuple[str, str]:
     patch_fix  = ""
     for hunk in PatchSet(patch):
         if any(
-            test_word in hunk.path for test_word in
+            test_word in hunk.path.lower() for test_word in
             ['test', 'tests', 'e2e', 'testing']
         ):
             patch_test += str(hunk)


### PR DESCRIPTION
## Summary
- The test keyword matching in `extract_patches()` was case-sensitive, causing paths like `spotbugsTestCases/` (uppercase `T`) to be misclassified as solution patch instead of test patch.
- This made test fixtures unreachable by agents, causing guaranteed F2P failures for affected instances (e.g., `spotbugs__spotbugs-3544` and likely all 7 spotbugs instances in the Java split).
- Fix: apply `.lower()` to the file path before matching test keywords.

Fixes #48

## Test plan
- [ ] Verify that `spotbugsTestCases/src/java/ghIssues/Issue3463.java` is now classified as `test_patch`
- [ ] Verify that normal test paths (e.g., `spotbugs-tests/src/test/...`) still classify correctly
- [ ] Verify that main source paths (e.g., `spotbugs/src/main/...`) still classify as `patch`
- [ ] Re-run affected spotbugs instances to confirm F2P tests now pass

(Thanks Claude Code for finding such well-hidden problem hhh...)